### PR TITLE
Add #eql? and #== to allow equality checking of ContinuedFraction objects

### DIFF
--- a/lib/continued_fractions.rb
+++ b/lib/continued_fractions.rb
@@ -8,7 +8,7 @@
 #
 class ContinuedFraction
   attr_accessor :number, :quotients, :limit
-  
+
   # For a given number calculate its continued fraction quotients and convergents up to limit.
   #
   # The limit is 5 by default. Pass an integer in the second parameter to change it.
@@ -26,7 +26,7 @@ class ContinuedFraction
     @quotients = calculate_quotients
     @convergents = calculate_convergents
   end
-  
+
   # Return nth convergent.
   #
   # Example:
@@ -38,7 +38,7 @@ class ContinuedFraction
     raise(IndexError, "Convergent index must be greater than zero.") unless nth > 0
     convergents[nth-1]
   end
-  
+
   # Return array of convergents of the continued fraction instance up to the nth convergent as an array
   # comprising of numerators in [i,0] and denominators in [i,1].
   # If nth is nil, then return the entire list.
@@ -57,7 +57,7 @@ class ContinuedFraction
     nth ||= @convergents.length
     @convergents[0...nth]
   end
-  
+
   # Return array of convergents of the continued fraction instance converted as Rationals.
   # If nth is nil, then return the entire list.
   #
@@ -75,40 +75,55 @@ class ContinuedFraction
     nth ||= convergents.length
     convergents[0...nth].map{|convergent| convergent_to_rational(convergent)}
   end
-  
+
   def +(other)
     number_of(other) do |num,prec|
       evaluate("#{number} + #{num}",prec)
     end
   end
-  
+
   def -(other)
     number_of(other) do |num,prec|
       evaluate("#{number} - #{num}",prec)
     end
   end
-  
+
   def /(other)
     number_of(other) do |num,prec|
       evaluate("#{number} / #{num}",prec)
     end
   end
-  
+
   def *(other)
     number_of(other) do |num,prec|
       evaluate("#{number} * #{num}",prec)
     end
   end
-  
+
   def convergent_to_rational(convergent) #:nodoc:
     Rational(convergent[0],convergent[1])
   end
-  
+
+  ##
+  # a.eql?(b) iff a and b are equivalent objects without type coercion.
+  #
+  def eql?(other)
+    (number == other.number) && (limit == other.limit)
+  end
+
+  ##
+  # a == b iff a and b are equivalent objects with type coercion. We do not
+  # perform any type coercion so delegate to #eql?
+  #
+  def ==(other)
+    self.eql?(other)
+  end
+
   private
   def evaluate(exp, prec) #:nodoc:
     ContinuedFraction.new(eval(exp), prec)
   end
-  
+
   def number_of(n) #:nodoc:
     num = nil
     prec = nil
@@ -145,7 +160,7 @@ class ContinuedFraction
     end
     convs[2...nth+2]
   end
-  
+
   def convergence_matrix(n,m,fill=nil) #:nodoc:
     conv_mat = Array.new(n).map!{Array.new(m,fill)}
     conv_mat[0][0],conv_mat[1][1] = 0,0

--- a/spec/continued_fractions/continued_fraction_spec.rb
+++ b/spec/continued_fractions/continued_fraction_spec.rb
@@ -3,57 +3,57 @@ require File.join(File.dirname(__FILE__), "/../spec_helper")
 describe ContinuedFraction do
   let(:cf) { described_class.new(number,10) }
   let(:number) { rand }
-  
+
   it "returns an array of convergents" do
     expect(cf.convergents).to be_kind_of(Array)
   end
-  
+
   it "preserves the number input" do
     expect(cf.number).to eq number
   end
-  
+
   it "adds a number on the right-hand-side with a continued fraction and returns a continued fraction" do
     expect((cf + 3)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "subtracts a number on the right-hand-side from a continued fraction and returns a continued fraction" do
     expect((cf - 3)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "multiplies a number on the right-hand-side with a continued fraction and returns a continued fraction" do
     expect((cf * 3)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "divides a number on the right-hand-side with a continued fraction and returns a continued fraction" do
     expect((cf / 3)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "adds a continued fraction with another continued fraction and returns a continued fraction" do
     c = described_class.new(rand,20)
     expect((cf + c)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "subtracts a continued fraction with another continued fraction and returns a continued fraction" do
     c = described_class.new(rand,20)
     expect((cf - c)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "multiplies a continued fraction with another continued fraction and returns a continued fraction" do
     c = described_class.new(rand,20)
     expect((cf * c)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "divides a continued fraction with another continued fraction and returns a continued fraction" do
     c = described_class.new(rand,20)
     expect((cf / c)).to be_kind_of(ContinuedFraction)
   end
-  
+
   it "assigns the resulting continued fraction of a binary operation the max limit of the two operands" do
     c = described_class.new(rand,20)
     result = cf + c
     expect(result.limit).to eq [cf.limit,c.limit].max
   end
-  
+
   context 'with irrational numbers' do
     it "accurately calculates the convergents" do
       # First 10 convergents of PI are...
@@ -61,14 +61,14 @@ describe ContinuedFraction do
       cf = described_class.new(Math::PI,10)
       expect((cf.convergents_as_rationals - convs)).to be_empty
     end
-    
+
     it "contains convergents approaching the number" do
       0.upto(cf.convergents.length-2) do |i|
         convergent_rational_i_plus1, convergent_rational_i = cf.convergent_to_rational(cf.convergents[i+1]), cf.convergent_to_rational(cf.convergents[i])
         expect(((convergent_rational_i_plus1 - cf.number).abs <= (convergent_rational_i - cf.number).abs)).to be true
       end
     end
-    
+
     it "contains convergents which are expressed in lowest terms" do
       1.upto(cf.convergents.length-1) do |i|
         convergent_rational_i, convergent_rational_i_plus1 = cf.convergent_to_rational(cf.convergent(i)), cf.convergent_to_rational(cf.convergent(i+1))
@@ -76,15 +76,35 @@ describe ContinuedFraction do
       end
     end
   end
-  
+
   context 'with rational numbers' do
     it 'changes the limit to the number of convergents calculated' do
       expect(described_class.new(1.5, 10).limit).to be 2
     end
-    
+
     it 'calculates the convergents' do
       convs = [ '1/1', '3/2' ].map(&:to_r)
       expect(described_class.new(1.5, 10).convergents_as_rationals - convs).to be_empty
+    end
+  end
+
+  context "equality comparison" do
+    it "continued fractions with the same number and limit are considered eql?" do
+      num = rand
+      limit = rand(3..20)
+      cf_1 = described_class.new(num, limit)
+      cf_2 = described_class.new(num, limit)
+      # test using explict #eql? for clarity
+      expect(cf_1.eql?(cf_2)).to eq true
+    end
+
+    it "continued fractions with the same number and limit are considered ==" do
+      num = rand
+      limit = rand(3..20)
+      cf_1 = described_class.new(num, limit)
+      cf_2 = described_class.new(num, limit)
+      # test using explict == for clarity
+      expect(cf_1 == (cf_2)).to eq true
     end
   end
 end


### PR DESCRIPTION
- Implement #eql?
- Implement #== by delegating to #eql?

Sorry about the whitespace changes - my editor automatically removes trailing whitespace. I can re-do this without those changes if you want me to but I'm guessing its not a big deal.
