### PR TITLE
Add Float#to_continued_fraction convenience method

### DIFF
--- a/lib/continued_fractions.rb
+++ b/lib/continued_fractions.rb
@@ -1,3 +1,5 @@
+require "core_ext/float/to_continued_fraction"
+
 # ContinuedFractions
 #
 # Generates quotients and convergents for a given number
@@ -8,7 +10,11 @@
 #
 class ContinuedFraction
   attr_accessor :number, :quotients, :limit
-  
+
+  def self.default_limit
+    5
+  end
+
   # For a given number calculate its continued fraction quotients and convergents up to limit.
   #
   # The limit is 5 by default. Pass an integer in the second parameter to change it.
@@ -20,13 +26,13 @@ class ContinuedFraction
   #       @convergents=[[0, 1], [1, 0], [3, 1], [22, 7], [333, 106],
   #                     [355, 113], [103993, 33102], [104348, 33215], [208341, 66317], [312689, 99532], [833719, 265381], [1146408, 364913]]>
   #
-  def initialize(number,limit=5)
+  def initialize(number,limit=ContinuedFraction.default_limit)
     @number = number
     @limit = limit
     @quotients = calculate_quotients
     @convergents = calculate_convergents
   end
-  
+
   # Return nth convergent.
   #
   # Example:
@@ -38,7 +44,7 @@ class ContinuedFraction
     raise(IndexError, "Convergent index must be greater than zero.") unless nth > 0
     convergents[nth-1]
   end
-  
+
   # Return array of convergents of the continued fraction instance up to the nth convergent as an array
   # comprising of numerators in [i,0] and denominators in [i,1].
   # If nth is nil, then return the entire list.
@@ -57,7 +63,7 @@ class ContinuedFraction
     nth ||= @convergents.length
     @convergents[0...nth]
   end
-  
+
   # Return array of convergents of the continued fraction instance converted as Rationals.
   # If nth is nil, then return the entire list.
   #
@@ -75,40 +81,40 @@ class ContinuedFraction
     nth ||= convergents.length
     convergents[0...nth].map{|convergent| convergent_to_rational(convergent)}
   end
-  
+
   def +(other)
     number_of(other) do |num,prec|
       evaluate("#{number} + #{num}",prec)
     end
   end
-  
+
   def -(other)
     number_of(other) do |num,prec|
       evaluate("#{number} - #{num}",prec)
     end
   end
-  
+
   def /(other)
     number_of(other) do |num,prec|
       evaluate("#{number} / #{num}",prec)
     end
   end
-  
+
   def *(other)
     number_of(other) do |num,prec|
       evaluate("#{number} * #{num}",prec)
     end
   end
-  
+
   def convergent_to_rational(convergent) #:nodoc:
     Rational(convergent[0],convergent[1])
   end
-  
+
   private
   def evaluate(exp, prec) #:nodoc:
     ContinuedFraction.new(eval(exp), prec)
   end
-  
+
   def number_of(n) #:nodoc:
     num = nil
     prec = nil
@@ -145,7 +151,7 @@ class ContinuedFraction
     end
     convs[2...nth+2]
   end
-  
+
   def convergence_matrix(n,m,fill=nil) #:nodoc:
     conv_mat = Array.new(n).map!{Array.new(m,fill)}
     conv_mat[0][0],conv_mat[1][1] = 0,0

--- a/lib/core_ext/float/to_continued_fraction.rb
+++ b/lib/core_ext/float/to_continued_fraction.rb
@@ -1,0 +1,9 @@
+##
+# Give Float the ability to convert itself to its ContinuedFraction
+# representation.
+#
+class Float
+  def to_continued_fraction(limit = ContinuedFraction.default_limit)
+    ContinuedFraction.new(self, limit)
+  end
+end

--- a/spec/continued_fractions/float_to_continued_fraction_spec.rb
+++ b/spec/continued_fractions/float_to_continued_fraction_spec.rb
@@ -1,0 +1,22 @@
+require File.join(File.dirname(__FILE__), "/../spec_helper")
+
+describe "Float#_to_continued_fraction" do
+  let(:example_float) { Math::PI }
+
+  it "converts float to its continued fraction representation" do
+    subject = example_float.to_continued_fraction
+    explicit_cf = ContinuedFraction.new(example_float)
+
+    expect(explicit_cf.number).to eq(subject.number)
+    expect(explicit_cf.limit).to eq(subject.limit)
+  end
+
+  it "can accept an explicit limit" do
+    limit = rand(3..20)
+    subject = example_float.to_continued_fraction(limit)
+    explicit_cf = ContinuedFraction.new(example_float, limit)
+
+    expect(explicit_cf.number).to eq(subject.number)
+    expect(explicit_cf.limit).to eq(subject.limit)
+  end
+end


### PR DESCRIPTION
Not sure how you feel about extending built-ins so no worries if you would prefer not to have this.

Changes
- Open built-in ruby Float and add #to_continued_fraction which converts
  the float to its ContinuedFraction representation
- Allow #to_continued_fraction to take an optional limit argument

Again, sorry about whitespace, will change if you want me to.

cheers

/Eoin/
