### PR TITLE
Add comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## ContinuedFractions
+# ContinuedFractions
 
 * http://rubygems.org/gems/continued_fractions
 
-#### Description
+## Description
 
 Generates quotients and convergents for a given number.
 
-#### Synopsis
+## Synopsis
 
     require 'continued_fractions'
   
@@ -38,17 +38,20 @@ Generates quotients and convergents for a given number.
     cf + cf2
     => #<ContinuedFractions::ContinuedFraction:0x000001009d2708 @number=3.1799344075396196, @limit=20, @quotients=[3, 5, 1, 1, 3, 1, 5, 3, 7, 25, 1, 2, 15, 6, 1, 1, 2, 3, 1, 2], @convergents=[[3, 1], [16, 5], [19, 6], [35, 11], [124, 39], [159, 50], [919, 289], [2916, 917], [21331, 6708], [536191, 168617], [557522, 175325], [1651235, 519267], [25326047, 7964330], [153607517, 48305247], [178933564, 56269577], [332541081, 104574824], [844015726, 265419225], [2864588259, 900832499], [3708603985, 1166251724], [10281796229, 3233335947]]>
 
-#### Install
+## Install
 
 sudo gem install continued_fractions
 
-#### Requirements/Dependencies
+## Requirements/Dependencies
 
 * Ruby 2.2+
 * Depends on Ruby's Rational class
 
-##### Developers
+## Developers
 
 * RSpec required to run tests
-* Echoe required to run rake tasks
-  
+
+## Contributors
+
+* [Jose Hales-Garcia](https://github.com/jolohaga)
+* [Eoin Kelly](https://github.com/eoinkelly)

--- a/lib/continued_fractions.rb
+++ b/lib/continued_fractions.rb
@@ -7,6 +7,8 @@
 #
 #
 class ContinuedFraction
+  include ::Comparable
+
   attr_accessor :number, :quotients, :limit
   
   # For a given number calculate its continued fraction quotients and convergents up to limit.
@@ -99,6 +101,10 @@ class ContinuedFraction
       evaluate("#{number} * #{num}",prec)
     end
   end
+
+  def <=>(other)
+    number <=> other.number
+  end
   
   def convergent_to_rational(convergent) #:nodoc:
     Rational(convergent[0],convergent[1])
@@ -108,7 +114,7 @@ class ContinuedFraction
   def evaluate(exp, prec) #:nodoc:
     ContinuedFraction.new(eval(exp), prec)
   end
-  
+
   def number_of(n) #:nodoc:
     num = nil
     prec = nil

--- a/lib/continued_fractions/version.rb
+++ b/lib/continued_fractions/version.rb
@@ -1,3 +1,3 @@
 module ContinuedFractions
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end

--- a/spec/continued_fractions/continued_fraction_spec.rb
+++ b/spec/continued_fractions/continued_fraction_spec.rb
@@ -68,4 +68,23 @@ describe ContinuedFraction do
       end
     end
   end
+
+  describe 'comparing' do
+    context 'when numbers are the same' do
+      let(:cf2) { described_class.new(cf.number) }
+
+      it "the ContinuedFractions are equal" do
+        expect(cf).to eq cf2
+      end
+    end
+
+    context 'when numbers are different' do
+      let(:cond) { [['+', '<'], ['-', '>']].sample }
+      let(:cf2) { described_class.new(cf.number.send(cond[0], 1.0)) }
+
+      it "the ContinuedFractions are unequal" do
+        expect(cf.send(cond[1], cf2)).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Continued fractions are orderable, so should ContinuedFractions.

This commit mixes in the Comparable module and defines the spaceship
operator, so ContinuedFractions can be ordered.

Comparison is restricted to `ContinuedFraction#number`.  `#limit`
shouldn't be part of the comparison, since precision isn't lost in
operations between ContinuedFractions, i.e. the larger of the two limits
is is returned in the result.